### PR TITLE
Add new product variable DeviceIsContainer

### DIFF
--- a/android/variable.go
+++ b/android/variable.go
@@ -103,6 +103,7 @@ type productVariables struct {
 	DeviceAbi         *[]string `json:",omitempty"`
 	DeviceUsesClang   *bool     `json:",omitempty"`
 	DeviceVndkVersion *string   `json:",omitempty"`
+	DeviceIsContainer *bool     `json:",omitempty"`
 
 	DeviceSecondaryArch        *string   `json:",omitempty"`
 	DeviceSecondaryArchVariant *string   `json:",omitempty"`

--- a/cc/makevars.go
+++ b/cc/makevars.go
@@ -136,6 +136,9 @@ func makeVarsToolchain(ctx android.MakeVarsContext, secondPrefix string,
 	if target.Os.Class == android.Device && Bool(ctx.Config().ProductVariables.Brillo) {
 		productExtraCflags += "-D__BRILLO__"
 	}
+	if target.Os.Class == android.Device && Bool(ctx.Config().ProductVariables.DeviceIsContainer) {
+		productExtraCflags += "-DANDROID_CONTAINER"
+	}
 	if target.Os.Class == android.Host && Bool(ctx.Config().ProductVariables.HostStaticBinaries) {
 		productExtraLdflags += "-static"
 	}


### PR DESCRIPTION
To accommodate to container based, less priviledged environment, some functions have to be disabled to successfully launch Android runtime. DeviceIsContainer is supposed to be set to true when BOARD_IS_CONTAINER is defined in per device BoardConfig.mk, and will inject C proprocessor definition ANDROID_CONTAINER for all native device modules.

Change-Id: I9c61080f2f29276432d323e3757ebc121b3e3a8c